### PR TITLE
Change koko-analytics filter to only block tracking script

### DIFF
--- a/easyprivacy/easyprivacy_general.txt
+++ b/easyprivacy/easyprivacy_general.txt
@@ -2632,7 +2632,7 @@
 /kiwip.js
 /klaviyo_analytics.
 /KochavaAnalytics.
-/koko-analytics/*
+/koko-analytics/*/script.js*
 /kontera.js
 /konterayahoooo.
 /kooomo.tracker.


### PR DESCRIPTION
The current filter breaks the entire Koko Analytics plugin for website owners, because the JavaScript file for showing their analytics dashboard breaks too. With this change, only the tracking script is blocked while the showing of statistics keeps working for website owners also running an ad-blocker w/ EasyPrivacy.

Also see #12973